### PR TITLE
use more permissive engine ranges

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   },
   "optionalDependencies": {},
   "engines": {
-    "node": "0.10.x",
-    "npm": "1.2.x"
+    "node": ">=0.10",
+    "npm": ">=1.2"
   },
   "main": "lib/licenses.json",
   "scripts": {


### PR DESCRIPTION
So I don't see this when I npm install: `npm WARN engine osi-licenses@0.1.0: wanted: {"node":"0.10.x","npm":"1.2.x"} (current: {"node":"1.5.1","npm":"2.7.5"})`
